### PR TITLE
chore: Update SonarCloud analysis workflow to remove commented code

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yaml
+++ b/.github/workflows/sonarcloud-analysis.yaml
@@ -1,12 +1,12 @@
 name: SonarCloud Analysis
 
 on:
-  push:
-    branches:
-      - main
-      - 12-fix-sonarcloud-scan
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # push:
+  #   branches:
+  #     - main
+  #     - 12-fix-sonarcloud-scan
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Invoke sonarcloud using manual trigger and let the SonarCloud Github App do the job instead of actions workflow